### PR TITLE
Fixed submenus

### DIFF
--- a/templates/partials/navigation.html.twig
+++ b/templates/partials/navigation.html.twig
@@ -8,7 +8,7 @@
                     {{ p.menu }}
                 </a>
                 <ul>
-                    {{ navigation.loop(p) }}
+                    {{ _self.loop(p) }}
                 </ul>
             </li>
         {% else %}


### PR DESCRIPTION
Had to change

    <ul>
        {{ navigation.loop(p) }}
    </ul>

 back to

    <ul>
        {{ _self.loop(p) }}
    </ul>

 to make submenus work again.
